### PR TITLE
リンク集のリンク切れを修正

### DIFF
--- a/source/link.html.haml
+++ b/source/link.html.haml
@@ -2,5 +2,5 @@
   %h2 リンク集
   %dl
     %dt
-      %a{href: "http://www.ekikara.jp/newdata/station/13111271.htm"} えきから時刻表　大鳥居
-    %dd 大鳥居駅の時刻表が見れます。
+      %a{href: "https://norikae.keikyu.co.jp/transit/norikae/T1?sf=%91%e5%92%b9%8b%8f"} 京急電鉄｜各駅時刻表
+    %dd 大鳥居駅の時刻表が検索できます。


### PR DESCRIPTION
fix #15

「えきから時刻表」がなくなってしまったようなので「京急電鉄の時刻表」のページに変えた。